### PR TITLE
feature: enable running travis-worker on MRI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 ruby '1.9.3', engine: 'jruby', engine_version: '1.7.16' if ENV.key?('DYNO')
 
 gem 'travis-build',     git: 'https://github.com/travis-ci/travis-build'
-gem 'travis-support',   git: 'https://github.com/travis-ci/travis-support'
+#gem 'travis-support',   git: 'https://github.com/travis-ci/travis-support'
+#gem 'travis-support',   git: 'git@github.com:finalci/travis-support.git'
+gem 'travis-support',   path: '../travis-support'
 
 gem 'celluloid',        git: 'https://github.com/celluloid/celluloid', ref: '5a56056'
 
@@ -26,7 +28,14 @@ gem 'sshjr',            git: 'https://github.com/joshk/sshjr'
 
 gem 'metriks',          '0.9.9.5'
 
-gem 'march_hare',       '2.7.0'
+platform :mri do
+  gem 'bunny',            '~> 1.7.0'
+end
+
+platform :jruby do
+  gem 'march_hare',       '2.7.0'
+end
+
 
 gem 'sentry-raven',     require: 'raven'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,8 @@ GIT
   specs:
     travis-build (0.0.1)
 
-GIT
-  remote: https://github.com/travis-ci/travis-support
-  revision: 40365216662f639d36fc3a0463c4e189ee1563dd
+PATH
+  remote: ../travis-support
   specs:
     travis-support (0.0.1)
 
@@ -32,11 +31,14 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.6)
+    amq-protocol (1.9.2)
     archive-tar-minitar (0.5.2)
     atomic (1.1.16)
     atomic (1.1.16-java)
     avl_tree (1.1.3)
     builder (3.2.2)
+    bunny (1.7.0)
+      amq-protocol (>= 1.9.2)
     coder (0.4.0)
     coderay (1.1.0)
     crack (0.4.2)
@@ -193,6 +195,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 3.2)
+  bunny (~> 1.7.0)
   celluloid!
   coder
   docker-api

--- a/lib/travis/worker/application.rb
+++ b/lib/travis/worker/application.rb
@@ -1,8 +1,8 @@
-require 'java'
-require 'march_hare'
+require "java" if (RUBY_PLATFORM == 'java')
 require 'metriks'
 require 'metriks/reporter/librato_metrics'
 require 'raven'
+require 'travis/support'
 require 'travis/support/amqp'
 require 'travis/support/logger'
 require 'travis/worker/pool'
@@ -19,6 +19,7 @@ module Travis
       def initialize
         Travis::Logger.configure(Travis.logger)
         Travis::Amqp.config = config.amqp
+        #Travis::Amqp.connect
 
         if config.sentry.dsn
           Raven.configure do |raven_config|
@@ -79,7 +80,7 @@ module Travis
       log :terminate
 
       def broker_connection
-        @broker_connection ||= MarchHare.connect(amqp_config)
+        @broker_connection ||= Travis::Amqp.connect
       end
 
       protected
@@ -111,15 +112,11 @@ module Travis
       end
 
       def workers
-        @workers ||= Pool.create(broker_connection)
-      end
-
-      def heartbeat_channel
-        @heartbeat_channel ||= broker_connection.create_channel
+        @workers ||= Pool.create
       end
 
       def heart
-        @heart ||= Heart.new(heartbeat_channel) { { :workers => workers.status } }
+        @heart ||= Heart.new { { :workers => workers.status } }
       end
 
       def update
@@ -147,7 +144,7 @@ module Travis
 
       def disconnect
         heart.stop
-        broker_connection.close if broker_connection.open?
+        Travis::Amqp.disconnect
         sleep(0.5)
       end
       log :disconnect

--- a/lib/travis/worker/application/heart.rb
+++ b/lib/travis/worker/application/heart.rb
@@ -11,10 +11,10 @@ module Travis
 
         attr_reader :exchange, :interval, :application
 
-        def initialize(channel, &block)
+        def initialize(&block)
           @status   = block
           @interval = Travis::Worker.config.heartbeat.interval
-          @channel  = channel
+          @channel  = Travis::Amqp.connection.create_channel
           @exchange = @channel.default_exchange
 
           @target_queue_name = 'reporting.workers'

--- a/lib/travis/worker/cli/development.rb
+++ b/lib/travis/worker/cli/development.rb
@@ -1,7 +1,9 @@
 require "thor"
 
-require "java"
-require "march_hare"
+require "java" if (RUBY_PLATFORM == 'java')
+require 'travis/support'
+require 'travis/support/amqp'
+
 require "multi_json"
 require 'travis/worker'
 

--- a/lib/travis/worker/factory.rb
+++ b/lib/travis/worker/factory.rb
@@ -4,16 +4,15 @@ require 'travis/worker/virtual_machine'
 module Travis
   module Worker
     class Factory
-      attr_reader :name, :config, :broker_connection
+      attr_reader :name, :config
 
-      def initialize(name, config = nil, broker_connection = nil)
+      def initialize(name, config = nil)
         @name              = name
         @config            = config
-        @broker_connection = broker_connection
       end
 
       def worker
-        Instance.new(name, vm, broker_connection, queue_name, config)
+        Instance.new(name, vm, queue_name, config)
       end
 
       def vm

--- a/lib/travis/worker/instance.rb
+++ b/lib/travis/worker/instance.rb
@@ -18,31 +18,40 @@ module Travis
 
       log_header { "#{name}:worker:instance" }
 
-      def self.create(name, config, broker_connection)
-        Factory.new(name, config, broker_connection).worker
+      def self.create(name, config)
+        Factory.new(name, config).worker
       end
 
       STATES = [:created, :starting, :ready, :working, :stopping, :stopped, :errored]
 
       attr_accessor :state
-      attr_reader :name, :vm, :broker_connection, :queue, :queue_name,
+      attr_reader :name, :vm, :queue_name,
                   :subscription, :config, :payload, :last_error, :observers, :reporter
 
-      def initialize(name, vm, broker_connection, queue_name, config, observers = [])
+      def initialize(name, vm, queue_name, config, observers = [])
         raise ArgumentError, "worker name cannot be nil!" if name.nil?
         raise ArgumentError, "VM cannot be nil!" if vm.nil?
-        raise ArgumentError, "broker connection cannot be nil!" if broker_connection.nil?
         raise ArgumentError, "config cannot be nil!" if config.nil?
 
         @name              = name
         @vm                = vm
         @queue_name        = queue_name
-        @broker_connection = broker_connection
         @config            = config
         @observers         = Array(observers)
 
         # create the reporter early so it is not created within the `process` callback
-        @reporter = Reporter.new(name, broker_connection.create_channel, broker_connection.create_channel)
+        @reporter = Reporter.new(name,
+           builds_publisher,
+           logs_publisher
+        )
+      end
+
+      def builds_publisher
+        @builds_publisher ||= Travis::Amqp::Publisher.jobs('builds', unique_channel: true, dont_retry: true)
+      end
+
+      def logs_publisher
+        @logs_publisher ||= Travis::Amqp::Publisher.jobs('logs', unique_channel: true, dont_retry: true)
       end
 
       def start
@@ -127,42 +136,28 @@ module Travis
       def open_channels
         # error handling happens on the per-channel basis, so using
         # one channel for one type of operation is a highly recommended practice. MK.
-        build_channel
-        reporting_channel
+        build_consumer
       end
 
       def close_channels
         # channels may be nil in some tests that mock out #start and #stop. MK.
-        build_channel.close if build_channel.open?
+        build_consumer.unsubscribe if build_consumer.nil?
         reporting_channel.close if reporting_channel && reporting_channel.open?
       end
 
-      def build_channel
-        # technically there is no need to use one channel per consumer but with RabbitMQ version on
-        # Heroku (2.5) this is the only way to go :/ 2.6 and 2.7 on my local network work just fine.
-        # But hey, Heroku gods, we must obey to. For now. MK.
-        @build_channel ||= begin
-          channel = broker_connection.create_channel
-          channel.prefetch = 1
-          channel
-        end
-      end
-
-      def reporting_channel
-        @reporting_channel ||= broker_connection.create_channel
+      def build_consumer
+        @build_consumer ||= Travis::Amqp::Consumer.builds
       end
 
       def declare_queues
-        @queue = build_channel.queue(queue_name, :durable => true)
-
         # these are declared here mostly to aid development purposes. MK
-        reporting_channel = broker_connection.create_channel
+        reporting_channel = Travis::Amqp.connection.create_channel
         reporting_channel.queue("reporting.jobs.builds", :durable => true)
         reporting_channel.queue("reporting.jobs.logs",   :durable => true)
       end
 
       def subscribe
-        @subscription = queue.subscribe(:ack => true, :blocking => false, &method(:process))
+        @subscription = @build_consumer.subscribe(:ack => true, :blocking => false, &method(:process))
       end
 
       def unsubscribe

--- a/lib/travis/worker/pool.rb
+++ b/lib/travis/worker/pool.rb
@@ -9,16 +9,15 @@ module Travis
     end
 
     class Pool
-      def self.create(broker_connection)
-        new(Travis::Worker.config.names, Travis::Worker.config, broker_connection)
+      def self.create
+        new(Travis::Worker.config.names, Travis::Worker.config)
       end
 
-      attr_reader :names, :config, :broker_connection
+      attr_reader :names, :config
 
-      def initialize(names, config, broker_connection)
+      def initialize(names, config)
         @names  = names
         @config = config
-        @broker_connection = broker_connection
       end
 
       def start(names)
@@ -39,7 +38,7 @@ module Travis
       end
 
       def workers
-        @workers ||= names.map { |name| Worker::Instance.create(name, config, broker_connection) }
+        @workers ||= names.map { |name| Worker::Instance.create(name, config) }
       end
 
       def worker(name)

--- a/lib/travis/worker/ssh/session.rb
+++ b/lib/travis/worker/ssh/session.rb
@@ -2,7 +2,7 @@ require 'shellwords'
 require 'travis/worker/utils/buffer'
 require 'travis/worker/utils/hard_timeout'
 require 'travis/worker/ssh/connector/net_ssh'
-require 'travis/worker/ssh/connector/sshjr'
+require 'travis/worker/ssh/connector/sshjr' if (RUBY_PLATFORM == 'java')
 require 'travis/support/logging'
 require 'base64'
 require 'hashr'
@@ -21,9 +21,10 @@ module Travis
         end
 
         CONNECTORS = {
-          net_ssh: Connector::NetSSH,
-          sshjr:   Connector::SSHJr,
+          net_ssh: Connector::NetSSH
         }
+
+        CONNECTORS[:sshjr] =  Connector::SSHJr if defined?(Connects::SSHJr)
 
         log_header { "#{name}:shell:session" }
 

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 require 'travis/worker/factory'
+require 'travis/support/amqp'
 
 describe Travis::Worker::Factory do
-  include_context "march_hare connection"
 
   let(:config)  { Hashr.new({ :queue => "builds.php" }) }
-  let(:factory) { Travis::Worker::Factory.new('worker-name', config, connection) }
+  let(:factory) { Travis::Worker::Factory.new('worker-name', config) }
   let(:worker)  { factory.worker }
 
   describe 'worker' do

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Worker::Pool do
   include_context "march_hare connection"
 
   let(:names)   { %w(worker-1 worker-2)}
-  let(:pool)    { Travis::Worker::Pool.new(names, Travis::Worker.config, connection) }
+  let(:pool)    { Travis::Worker::Pool.new(names, Travis::Worker.config) }
   let(:workers) { names.map { |name| stub(name, :name => name, :boot => nil, :start => nil, :stop => nil) } }
 
   before :each do

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'travis/worker/reporter'
+require 'travis/support'
+require 'travis/support/amqp'
 
 describe Travis::Worker::Reporter do
   include_context 'march_hare connection'
@@ -8,7 +10,10 @@ describe Travis::Worker::Reporter do
   let(:routing_key) { 'reporting.jobs.logs' }
   let(:queue)       { channel.queue(routing_key, :durable => true) }
   let(:reporting_exchange) { channel.exchange('reporting', :type => :topic, :durable => true) }
-  let(:reporter)    { described_class.new('staging-1', connection.create_channel, connection.create_channel) }
+  let(:reporter)    { described_class.new('staging-1',
+    Travis::Amqp::Publisher.jobs('builds', unique_channel: true, dont_retry: true),
+    Travis::Amqp::Publisher.jobs('logs', unique_channel: true, dont_retry: true)
+  ) }
 
   include Travis::Worker::Utils::Serialization
 
@@ -18,9 +23,24 @@ describe Travis::Worker::Reporter do
       queue.bind(reporting_exchange, :routing_key => routing_key)
     end
 
+
+
+
     it 'publishes log chunks' do
       reporter.notify('build:log', :log => '...')
       sleep 0.5
+      meta, payload = queue.get
+
+      expect(decode(payload)).to eq({ :log => '...', :uuid => Travis.uuid })
+      expect(meta.properties.type).to eq('build:log')
+    end
+
+
+
+
+    it 'publishes log chunks' do
+
+      reporter.notify('build:log', :log => '...')
       meta, payload = queue.get
 
       expect(decode(payload)).to eq({ :log => '...', :uuid => Travis.uuid })

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "bundler/setup"
 require 'rspec'
 require 'mocha'
 require 'hashr'
-require 'march_hare'
+#require 'march_hare'
 require 'webmock/rspec'
 
 require 'travis/worker'

--- a/spec/support/hot_bunnies.rb
+++ b/spec/support/hot_bunnies.rb
@@ -1,4 +1,7 @@
 shared_context "march_hare connection" do
-  let(:connection) { MarchHare.connect(:hostname => "127.0.0.1") }
-  after(:each)     { connection.close }
+  let(:connection) {
+    Travis::Amqp.config = { hostname: '127.0.0.1' }
+    Travis::Amqp.connect
+  }
+  after(:each)     { Travis::Amqp.disconnect;sleep 0.1 }
 end


### PR DESCRIPTION
It is not suppoused to use MRI in production, but development is really
faster!

Futhermore, it is a pre-requirement for KVM support (fog libvirt is
working only on MRI).
